### PR TITLE
Reconfigure pydantic schema, modify return type of endpoints, add database context management and add update endpoint

### DIFF
--- a/fastapi_ecom/database/db_setup.py
+++ b/fastapi_ecom/database/db_setup.py
@@ -19,5 +19,9 @@ def get_db():
     db = SessionLocal()
     try:
         yield db
+        db.commit()
+    except Exception:
+        db.rollback()
+        raise
     finally:
         db.close()

--- a/fastapi_ecom/database/pydantic_schemas/business.py
+++ b/fastapi_ecom/database/pydantic_schemas/business.py
@@ -1,8 +1,22 @@
+from abc import ABC
 from datetime import datetime
+from typing import List
+
 from pydantic import BaseModel
 
+from fastapi_ecom.database.pydantic_schemas.util import APIResult
 
-class BusinessBase(BaseModel):
+
+class BusinessBase(BaseModel, ABC):
+    """
+    Base: Business
+    """
+
+    class Config:
+        from_attributes = True
+
+
+class BusinessView(BusinessBase):
     email: str
     name: str
     addr_line_1: str
@@ -10,14 +24,25 @@ class BusinessBase(BaseModel):
     city: str
     state: str
 
-class BusinessCreate(BusinessBase):
+
+class BusinessCreate(BusinessView):
     password: str
 
-class Business(BusinessBase):
-    id: int
-    is_verified: bool
-    creation_date: datetime
-    uuid: str
 
-    class Config:
-        orm_mode = True
+class BusinessUpdate(BusinessCreate):
+    pass
+
+
+class BusinessInternal(BusinessUpdate):
+    id: int
+    uuid: str
+    is_verified: bool = False
+    creation_date: datetime
+
+
+class BusinessResult(APIResult):
+    business: BusinessView
+
+
+class BusinessManyResult(APIResult):
+    businesses: List[BusinessView] = []

--- a/fastapi_ecom/database/pydantic_schemas/customer.py
+++ b/fastapi_ecom/database/pydantic_schemas/customer.py
@@ -1,8 +1,22 @@
+from abc import ABC
 from datetime import datetime
+from typing import List
+
 from pydantic import BaseModel
 
+from fastapi_ecom.database.pydantic_schemas.util import APIResult
 
-class CustomerBase(BaseModel):
+
+class CustomerBase(BaseModel, ABC):
+    """
+    Base: Customer
+    """
+
+    class Config:
+        from_attributes = True
+
+
+class CustomerView(CustomerBase):
     email: str
     name: str
     addr_line_1: str
@@ -10,14 +24,25 @@ class CustomerBase(BaseModel):
     city: str
     state: str
 
-class CustomerCreate(CustomerBase):
+
+class CustomerCreate(CustomerView):
     password: str
 
-class Customer(CustomerBase):
-    id: int
-    is_verified: bool
-    creation_date: datetime
-    uuid: str
 
-    class Config:
-        orm_mode = True
+class CustomerUpdate(CustomerCreate):
+    pass
+
+
+class CustomerInternal(CustomerUpdate):
+    id: int
+    uuid: str
+    is_verified: bool = False
+    creation_date: datetime
+
+
+class CustomerResult(APIResult):
+    customer: CustomerView
+
+
+class CustomerManyResult(APIResult):
+    customers: List[CustomerView] = []

--- a/fastapi_ecom/database/pydantic_schemas/util.py
+++ b/fastapi_ecom/database/pydantic_schemas/util.py
@@ -1,0 +1,16 @@
+from abc import ABC
+from enum import Enum
+from typing import Optional
+
+from pydantic import BaseModel
+
+
+class APIResultAction(str, Enum):
+    get = "get"
+    post = "post"
+    put = "put"
+    delete = "delete"
+
+
+class APIResult(BaseModel, ABC):
+    action: Optional[APIResultAction]

--- a/fastapi_ecom/main.py
+++ b/fastapi_ecom/main.py
@@ -3,15 +3,23 @@ from fastapi import FastAPI
 from fastapi_ecom.router import customer, business
 
 
+tags_metadata = [
+    {"name": "customer", "description": "Operations on customeres"},
+    {"name": "business", "description": "Operations on businesses"},
+]
+
 app = FastAPI(
         title="FastAPI ECOM",
         description="E-Commerce API for businesses and end users using FastAPI.",
-        version="0.1.0"
+        version="0.1.0",
+        openapi_tags=tags_metadata,
     )
+
+PREFIX = "/api/v1"
 
 @app.get("/")
 def root():
     return{"message": "This is an E-Commerce API for businesses and end users using FastAPI."}
 
-app.include_router(customer.router)
-app.include_router(business.router)
+app.include_router(customer.router, prefix=PREFIX)
+app.include_router(business.router, prefix=PREFIX)

--- a/fastapi_ecom/router/customer.py
+++ b/fastapi_ecom/router/customer.py
@@ -2,36 +2,49 @@ from fastapi import APIRouter, Depends, HTTPException
 
 from sqlalchemy.orm import Session
 
-from typing import List
-
 from fastapi_ecom.database.db_setup import get_db
-from fastapi_ecom.database.pydantic_schemas.customer import Customer, CustomerCreate
-from fastapi_ecom.utils.crud.customer import create_customer, get_customers ,get_customer_by_email, delete_customer
+from fastapi_ecom.database.pydantic_schemas.customer import CustomerCreate, CustomerUpdate, CustomerInternal, CustomerResult, CustomerManyResult
+from fastapi_ecom.utils.crud.customer import create_customer, get_customers ,get_customer_by_email, delete_customer, modify_customer
 from fastapi_ecom.utils.auth import verify_cust_cred
 
 
-router = APIRouter()
+router = APIRouter(prefix="/customer")
 
-@router.post("/customer", response_model=Customer, status_code=201)
+@router.post("", response_model=CustomerResult, status_code=201, tags=["customer"])
 async def create_new_customer(customer: CustomerCreate, db: Session = Depends(get_db)):
-    db_customer = get_customer_by_email(db=db, email=customer.email)
-    if db_customer:
-        raise HTTPException(status_code=400, detail="Try a new Email! Email is already registered")
-    return create_customer(db=db, customer=customer)
+    new_customer = create_customer(db=db, customer=customer)
+    return {
+        "action": "post",
+        "customer": new_customer
+    }
 
-@router.get("/customer/me")
-async def read_customer_me(email: str = Depends(verify_cust_cred)):
-    return {"email": email}
+@router.get("/me", tags=["customer"])
+async def read_customer_me(customer_auth: CustomerInternal = Depends(verify_cust_cred)):
+    return {
+        "action": "get",
+        "email": customer_auth.email
+    }
 
-@router.get("/customer", response_model=List[Customer])
+@router.get("", response_model=CustomerManyResult, tags=["customer"])
 async def read_customers(skip: int = 0, limit: int = 100, db: Session = Depends(get_db)):
     customers = get_customers(db, skip=skip, limit=limit)
-    return customers
+    return {
+        "action": "get",
+        "customers": customers
+    }
 
-@router.delete("/customer/delete/me")
-async def dlt_customer(db: Session = Depends(get_db), email: str = Depends(verify_cust_cred)):
-    db_customer = get_customer_by_email(db=db, email=email)
-    if db_customer is None:
-        raise HTTPException(status_code=404, detail="Customer not present in database")
-    customer_to_delete = delete_customer(db=db, uuid=db_customer.uuid)
-    return customer_to_delete
+@router.delete("/delete/me", response_model=CustomerResult, tags=["customer"])
+async def dlt_customer(db: Session = Depends(get_db), customer_auth: CustomerInternal = Depends(verify_cust_cred)):
+    customer_to_delete = delete_customer(db=db, uuid=customer_auth.uuid)
+    return {
+        "action": "delete",
+        "customer": customer_to_delete
+    }
+
+@router.put("/update/me", response_model=CustomerResult, tags=["customer"])
+async def updt_customer(customer: CustomerUpdate, db: Session = Depends(get_db), customer_auth: CustomerInternal = Depends(verify_cust_cred)):
+    customer_to_update = modify_customer(db=db, customer=customer, uuid=customer_auth.uuid)
+    return {
+        "action": "put",
+        "customer": customer_to_update
+    }

--- a/fastapi_ecom/router/customer.py
+++ b/fastapi_ecom/router/customer.py
@@ -1,10 +1,10 @@
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends
 
 from sqlalchemy.orm import Session
 
 from fastapi_ecom.database.db_setup import get_db
 from fastapi_ecom.database.pydantic_schemas.customer import CustomerCreate, CustomerUpdate, CustomerInternal, CustomerResult, CustomerManyResult
-from fastapi_ecom.utils.crud.customer import create_customer, get_customers ,get_customer_by_email, delete_customer, modify_customer
+from fastapi_ecom.utils.crud.customer import create_customer, get_customers, delete_customer, modify_customer
 from fastapi_ecom.utils.auth import verify_cust_cred
 
 

--- a/fastapi_ecom/utils/auth.py
+++ b/fastapi_ecom/utils/auth.py
@@ -28,7 +28,7 @@ def verify_cust_cred(credentials: HTTPBasicCredentials = Depends(security), db: 
             headers={"WWW-Authenticate": "Basic"},
         )
     else:
-        return customer.email
+        return customer
 
 def verify_business_cred(credentials: HTTPBasicCredentials = Depends(security), db: Session = Depends(get_db)):
     business = get_business_by_email(db, credentials.username)

--- a/fastapi_ecom/utils/auth.py
+++ b/fastapi_ecom/utils/auth.py
@@ -15,7 +15,6 @@ security = HTTPBasic()
 def verify_cust_cred(credentials: HTTPBasicCredentials = Depends(security), db: Session = Depends(get_db)):
     customer = get_customer_by_email(db, credentials.username)
     if not customer:
-         print("No customer present")
          raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Invalid authentication credentials",
@@ -33,7 +32,6 @@ def verify_cust_cred(credentials: HTTPBasicCredentials = Depends(security), db: 
 def verify_business_cred(credentials: HTTPBasicCredentials = Depends(security), db: Session = Depends(get_db)):
     business = get_business_by_email(db, credentials.username)
     if not business:
-         print("No business present")
          raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Invalid authentication credentials",
@@ -46,4 +44,4 @@ def verify_business_cred(credentials: HTTPBasicCredentials = Depends(security), 
             headers={"WWW-Authenticate": "Basic"},
         )
     else:
-        return business.email
+        return business

--- a/fastapi_ecom/utils/crud/business.py
+++ b/fastapi_ecom/utils/crud/business.py
@@ -1,14 +1,18 @@
 import bcrypt
 
+from fastapi import HTTPException, status
+
+from sqlalchemy import delete
 from sqlalchemy.orm import Session
+from sqlalchemy.exc import IntegrityError
+
 from fastapi_ecom.database.models.business import Business
-from fastapi_ecom.database.pydantic_schemas.business import BusinessCreate
+from fastapi_ecom.database.pydantic_schemas.business import BusinessCreate, BusinessUpdate, BusinessView, BusinessInternal
 
 
 def create_business(db: Session, business: BusinessCreate):
     salt = bcrypt.gensalt()
     hashed_password = bcrypt.hashpw(business.password.encode('utf-8'), salt)
-    print('Encoded pwd:',business.password.encode('utf-8'),'Hashed pwd:',hashed_password,'Hashed decoded pwd:',hashed_password.decode('utf-8'))
     db_business = Business(email=business.email,
                            password=hashed_password.decode('utf-8'),
                            name=business.name,
@@ -17,21 +21,68 @@ def create_business(db: Session, business: BusinessCreate):
                            city=business.city,
                            state=business.state)
     db.add(db_business)
-    db.commit()
-    db.refresh(db_business)
-    return db_business
+    try:
+        db.flush()
+    except IntegrityError as expt:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Uniqueness constraint failed - Please try again"
+        )
+    return BusinessView.from_orm(db_business).dict()
 
-def get_business(db: Session, skip: int = 0, limit: int = 100):
-    return db.query(Business).offset(skip).limit(limit).all()
+def get_businesses(db: Session, skip: int = 0, limit: int = 100):
+    businesses = db.query(Business).offset(skip).limit(limit).all()
+    for business in businesses:
+        print(business)
+    return [BusinessView.from_orm(business).dict() for business in businesses]
 
 def get_business_by_email(db: Session, email: str):
-    return db.query(Business).filter(Business.email == email).first()
+    business_by_email = db.query(Business).filter(Business.email == email).first()
+    if business_by_email is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Business not present in database"
+        )
+    return BusinessInternal.from_orm(business_by_email)
 
 def get_business_by_uuid(db: Session, uuid: str):
-    return db.query(Business).filter(Business.uuid == uuid).first()
+    business_by_uuid = db.query(Business).filter(Business.uuid == uuid).first()
+    if business_by_uuid is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Business not present in database"
+        )
+    return BusinessInternal.from_orm(business_by_uuid)
 
 def delete_business(db: Session, uuid: str):
     business_to_delete = get_business_by_uuid(db=db, uuid=uuid)
-    db.delete(business_to_delete)
-    db.commit()
-    return business_to_delete
+    query = delete(Business).filter_by(uuid=uuid)
+    db.execute(query)
+    try:
+        db.flush()
+    except IntegrityError as expt:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Failed while deleting"
+        )
+    return BusinessView.from_orm(business_to_delete).dict()
+
+def modify_business(db: Session, business: BusinessUpdate, uuid: str):
+    business_to_update = db.query(Business).filter(Business.uuid == uuid).first()
+    business_to_update.email = business.email
+    business_to_update.name = business.name
+    business_to_update.addr_line_1 = business.addr_line_1
+    business_to_update.addr_line_2 = business.addr_line_2
+    business_to_update.city = business.city
+    business_to_update.state = business.state
+    salt = bcrypt.gensalt()
+    hashed_password = bcrypt.hashpw(business.password.encode('utf-8'), salt)
+    business_to_update.password = hashed_password.decode('utf-8')
+    try:
+        db.flush()
+    except IntegrityError as expt:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Failed while updating"
+        )
+    return BusinessView.from_orm(business_to_update).dict()

--- a/fastapi_ecom/utils/crud/customer.py
+++ b/fastapi_ecom/utils/crud/customer.py
@@ -1,14 +1,18 @@
 import bcrypt
 
+from fastapi import HTTPException
+
+from sqlalchemy import delete
 from sqlalchemy.orm import Session
+from sqlalchemy.exc import IntegrityError
+
 from fastapi_ecom.database.models.customer import Customer
-from fastapi_ecom.database.pydantic_schemas.customer import CustomerCreate
+from fastapi_ecom.database.pydantic_schemas.customer import CustomerCreate, CustomerUpdate, CustomerView, CustomerInternal
 
 
 def create_customer(db: Session, customer: CustomerCreate):
     salt = bcrypt.gensalt()
     hashed_password = bcrypt.hashpw(customer.password.encode('utf-8'), salt)
-    print('Encoded pwd:',customer.password.encode('utf-8'),'Hashed pwd:',hashed_password,'Hashed decoded pwd:',hashed_password.decode('utf-8'))
     db_customer = Customer(email=customer.email,
                            password=hashed_password.decode('utf-8'),
                            name=customer.name,
@@ -17,21 +21,51 @@ def create_customer(db: Session, customer: CustomerCreate):
                            city=customer.city,
                            state=customer.state)
     db.add(db_customer)
-    db.commit()
-    db.refresh(db_customer)
-    return db_customer
+    try:
+        db.flush()
+    except IntegrityError as expt:
+        raise HTTPException(status_code=409, detail="Uniqueness constraint failed - Please try again")
+    return CustomerView.from_orm(db_customer).dict()
 
 def get_customers(db: Session, skip: int = 0, limit: int = 100):
-    return db.query(Customer).offset(skip).limit(limit).all()
+    customers = db.query(Customer).offset(skip).limit(limit).all()
+    return [CustomerView.from_orm(cust).dict() for cust in customers]
 
 def get_customer_by_email(db: Session, email: str):
-    return db.query(Customer).filter(Customer.email == email).first()
+    customer_by_email = db.query(Customer).filter(Customer.email == email).first()
+    if customer_by_email is None:
+        raise HTTPException(status_code=404, detail="Customer not present in database")
+    return CustomerInternal.from_orm(customer_by_email)
 
 def get_customer_by_uuid(db: Session, uuid: str):
-    return db.query(Customer).filter(Customer.uuid == uuid).first()
+    customer_by_uuid = db.query(Customer).filter(Customer.uuid == uuid).first()
+    if customer_by_uuid is None:
+        raise HTTPException(status_code=404, detail="Customer not present in database")
+    return CustomerInternal.from_orm(customer_by_uuid)
 
 def delete_customer(db: Session, uuid: str):
     customer_to_delete = get_customer_by_uuid(db=db, uuid=uuid)
-    db.delete(customer_to_delete)
-    db.commit()
-    return customer_to_delete
+    query = delete(Customer).filter_by(uuid=uuid)
+    db.execute(query)
+    try:
+        db.flush()
+    except IntegrityError as expt:
+        raise HTTPException(status_code=400, detail="Failed while deleting")
+    return CustomerView.from_orm(customer_to_delete).dict()
+
+def modify_customer(db: Session, customer: CustomerUpdate, uuid: str):
+    customer_to_update = db.query(Customer).filter(Customer.uuid == uuid).first()
+    customer_to_update.email = customer.email
+    customer_to_update.name = customer.name
+    customer_to_update.addr_line_1 = customer.addr_line_1
+    customer_to_update.addr_line_2 = customer.addr_line_2
+    customer_to_update.city = customer.city
+    customer_to_update.state = customer.state
+    salt = bcrypt.gensalt()
+    hashed_password = bcrypt.hashpw(customer.password.encode('utf-8'), salt)
+    customer_to_update.password = hashed_password.decode('utf-8')
+    try:
+        db.flush()
+    except IntegrityError as expt:
+        raise HTTPException(status_code=400, detail="Failed while updating")
+    return CustomerView.from_orm(customer_to_update).dict()


### PR DESCRIPTION
Reconfigure pydantic schema, modify return type of endpoints, add database context management and add update endpoint

Reconfigure pydantic schema
1. Add new `util` schema for showing API results in a certain format
2. Add abstraction layer and include the results schema in both customer and business schema

Modify return type of endpoints
1. Add `prefixes` in router for easy access
2. Add `tags` in router to group the enpoints
3. Add `response_model` to display the results in desired format

Add database context management
1. Add database context manager in `db_setup.py`
2. Remove manual commit statement and use SQLAlchemy flush

Add update endpoint
1. Add update operation for both customer and business
2. Include the update operation in update endpoint

Signed-off-by: Shounak Dey <shounakdey@ymail.com>